### PR TITLE
initial_referrer cookie only set if not removed anyway

### DIFF
--- a/template.js
+++ b/template.js
@@ -336,7 +336,7 @@ function trackCommonData(postBody) {
         if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
     }
 
-    if (!data.trackParametersRemove || !data.trackParametersRemove.contains('$initial_referrer')) {
+    if (!data.trackParametersRemove || !data.trackParametersRemove.some(el => el.name === '$initial_referrer')) {
         let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
         if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
         if (!initialReferrer) {

--- a/template.js
+++ b/template.js
@@ -336,11 +336,13 @@ function trackCommonData(postBody) {
         if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
     }
 
-    let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
-    if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
-    if (!initialReferrer) {
-        postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
-        setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
+    if (!data.trackParametersRemove || !data.trackParametersRemove.contains('$initial_referrer')) {
+        let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
+        if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
+        if (!initialReferrer) {
+            postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
+            setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
+        }
     }
 
     if (postBody.properties['$initial_referrer'] && postBody.properties['$initial_referrer'] !== 'direct') postBody.properties['$initial_referring_domain'] = parseUrl(postBody.properties['$initial_referrer']).hostname;

--- a/template.tpl
+++ b/template.tpl
@@ -690,11 +690,13 @@ function trackCommonData(postBody) {
         if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
     }
 
-    let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
-    if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
-    if (!initialReferrer) {
-        postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
-        setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
+    if (!data.trackParametersRemove || !data.trackParametersRemove.contains('$initial_referrer')) {
+        let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
+        if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
+        if (!initialReferrer) {
+            postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
+            setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
+        }
     }
 
     if (postBody.properties['$initial_referrer'] && postBody.properties['$initial_referrer'] !== 'direct') postBody.properties['$initial_referring_domain'] = parseUrl(postBody.properties['$initial_referrer']).hostname;

--- a/template.tpl
+++ b/template.tpl
@@ -690,7 +690,7 @@ function trackCommonData(postBody) {
         if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
     }
 
-    if (!data.trackParametersRemove || !data.trackParametersRemove.contains('$initial_referrer')) {
+    if (!data.trackParametersRemove || !data.trackParametersRemove.some(el => el.name === '$initial_referrer')) {
         let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
         if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
         if (!initialReferrer) {


### PR DESCRIPTION
Hi. Thanks for the template! I'm been using it in an evironment where we don't want to set cookies. We manage distinct_id ourselves so no cookies are set for that, but there is not way of preventing the stape_mixpanel_initial_referrer cookie to be set, therefore this little change. 

It will check first if the initial_referrer property will not be removed from the tracking request anyway and will not bother to handle it if this is the case.

Regards
Alex
