### PR TITLE
List parameters

### DIFF
--- a/template.js
+++ b/template.js
@@ -180,6 +180,19 @@ function sendTrackRequest() {
         });
     }
 
+    if (data.trackList) {
+        data.trackList.forEach(d => {
+            // Check if listValues is a string and have commas
+            if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
+                // Convert a string to an array of strings, removing whitespace characters and dividing by commas
+                postBody.properties[d.listName] = d.listValues.split(',').map(tag => tag.trim());
+            } else {
+                // If it is not a comma-delimited string, assign the value of listValues unchanged
+                postBody.properties[d.listName] = d.listValues;
+            }
+        });
+    }
+    
     if (data.trackParametersRemove) {
         data.trackParametersRemove.forEach(d => {
             Object.delete(postBody.properties, d.name);

--- a/template.tpl
+++ b/template.tpl
@@ -298,6 +298,26 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "type": "SIMPLE_TABLE",
+        "name": "trackList",
+        "displayName": "Parameters as lists",
+        "simpleTableColumns": [
+          {
+            "defaultValue": "",
+            "displayName": "Parameter Name",
+            "name": "listName",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Values",
+            "name": "listValues",
+            "type": "TEXT"
+          }
+        ],
+        "help": "List of parameters separated by comma sent as a Data Type  \u003d \"list\". For Example: tags: tag1,tag2,tag3"
+      },
+      {
+        "type": "SIMPLE_TABLE",
         "name": "trackParametersRemove",
         "displayName": "Remove parameters from the request",
         "simpleTableColumns": [
@@ -533,6 +553,20 @@ function sendTrackRequest() {
             postBody.properties[d.name] = d.value;
         });
     }
+
+    if (data.trackList) {
+        data.trackList.forEach(d => {
+            // Check if listValues is a string and have commas
+            if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
+                // Convert a string to an array of strings, removing whitespace characters and dividing by commas
+                postBody.properties[d.listName] = d.listValues.split(',').map(tag => tag.trim());
+            } else {
+                // If it is not a comma-delimited string, assign the value of listValues unchanged
+                postBody.properties[d.listName] = d.listValues;
+            }
+        });
+    }
+
 
     if (data.trackParametersRemove) {
         data.trackParametersRemove.forEach(d => {


### PR DESCRIPTION
Added a feature of adding parameters in a list format which is useful when a property has a list of different values like post_tags, authors, colors etc... 

Values are sent in the following format:
`"test_list1":["prop1","prop2"]`

Mixpanel interprets it properly as a list:
![Screenshot 2024-04-29 at 20 14 44](https://github.com/stape-io/mixpanel-tag/assets/108008262/1be1c68e-231f-4786-b7e2-48180cb20dab)


[Reference: mixpanel.com](https://mixpanel.com/blog/tapping-into-advanced-data-types/ )