### PR TITLE
IP added to the set call

### DIFF
--- a/template.js
+++ b/template.js
@@ -115,6 +115,7 @@ function sendSetProfileRequest() {
     const profileBody = {
         '$token': data.token,
         '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
         '$set': userProperties
     };
 

--- a/template.tpl
+++ b/template.tpl
@@ -469,6 +469,7 @@ function sendSetProfileRequest() {
     const profileBody = {
         '$token': data.token,
         '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
         '$set': userProperties
     };
 


### PR DESCRIPTION
IP was added to the `set` call in order to pass users' localization data correctly. 