### PR TITLE
feat: add support for profile-set-once in Mixpanel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - Track - tracks Mixpanel events.
 - Alias - adds an alias to existing Mixpanel contact.
+- Set Once - sets user profile properties only if they are not already set.
 - Reset - resets identification of Mixpanel contact.
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,4 +21,5 @@ versions:
   - sha: 9c64ffe6b2160224ba7fd1e9c62c2a7929a0b1ef
     changeNotes: Add parameters variable support.
   - sha: f883b90a33f7e69e347af0d6ffffd039a69e987c
+    changeNotes: Enhanced 'set-once' user profile property support with improved UI configuration.
     changeNotes: Initial release.

--- a/template.js
+++ b/template.js
@@ -41,6 +41,8 @@ if (data.type === 'track') {
     sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
     sendAppendProfileRequest();
+} else if (data.type === 'profile-set-once') {
+    sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
     cookieOptions['max-age'] = 1;
     setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
@@ -140,6 +142,58 @@ function sendSetProfileRequest() {
                 'Type': 'Response',
                 'TraceId': traceId,
                 'EventName': 'Profile Set',
+                'ResponseStatusCode': statusCode,
+                'ResponseHeaders': headers,
+                'ResponseBody': body,
+            }));
+        }
+
+        // Handling the response
+        if (statusCode >= 200 && statusCode < 400) {
+            data.gtmOnSuccess();
+        } else {
+            data.gtmOnFailure();
+        }
+    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+}
+
+function sendSetOnceProfileRequest() {
+    const userProperties = {};
+    data.userPropertiesToSetOnce.forEach(row => {
+        userProperties[row.userProperty] = row.value;
+    });
+
+    const profileBody = {
+        '$token': data.token,
+        '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
+        '$set_once': userProperties
+    };
+
+    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+
+    // Logging the request if logging is enabled
+    if (isLoggingEnabled) {
+        logToConsole(JSON.stringify({
+            'Name': 'Mixpanel',
+            'Type': 'Request',
+            'TraceId': traceId,
+            'EventName': 'Profile Set Once',
+            'RequestMethod': 'POST',
+            'RequestUrl': postUrlSetOnce,
+            'RequestBody': profileBody,
+        }));
+    }
+
+    // Sending the HTTP request to Mixpanel
+    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
+        // Logging the response if logging is enabled
+        if (isLoggingEnabled) {
+            logToConsole(JSON.stringify({
+                'Name': 'Mixpanel',
+                'Type': 'Response',
+                'TraceId': traceId,
+                'EventName': 'Profile Set Once',
                 'ResponseStatusCode': statusCode,
                 'ResponseHeaders': headers,
                 'ResponseBody': body,

--- a/template.tpl
+++ b/template.tpl
@@ -344,6 +344,40 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "GROUP",
+    "name": "setOnceGroup",
+    "displayName": "User Properties to Set Once",
+    "groupStyle": "ZIPPY_OPEN",
+    "subParams": [
+      {
+        "type": "SIMPLE_TABLE",
+        "name": "userPropertiesToSetOnce",
+        "displayName": "",
+        "simpleTableColumns": [
+          {
+            "defaultValue": "",
+            "displayName": "User Property",
+            "name": "userProperty",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Value",
+            "name": "value",
+            "type": "TEXT"
+          }
+        ]
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "type",
+        "paramValue": "profile-set-once",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "displayName": "Logs Settings",
     "name": "logsGroup",
     "groupStyle": "ZIPPY_CLOSED",

--- a/template.tpl
+++ b/template.tpl
@@ -70,6 +70,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "profile-append",
         "displayValue": "append"
+      },
+      {
+        "value": "profile-set-once",
+        "displayValue": "set-once"
       }
     ],
     "simpleValueType": true,
@@ -415,6 +419,8 @@ if (data.type === 'track') {
     sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
     sendAppendProfileRequest();
+} else if (data.type === 'profile-set-once') {
+    sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
     cookieOptions['max-age'] = 1;
     setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
@@ -462,6 +468,58 @@ function sendAppendProfileRequest() {
                 'Type': 'Response',
                 'TraceId': traceId,
                 'EventName': 'Profile Append',
+                'ResponseStatusCode': statusCode,
+                'ResponseHeaders': headers,
+                'ResponseBody': body,
+            }));
+        }
+
+        // Handling the response
+        if (statusCode >= 200 && statusCode < 400) {
+            data.gtmOnSuccess();
+        } else {
+            data.gtmOnFailure();
+        }
+    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+}
+
+function sendSetOnceProfileRequest() {
+    const userProperties = {};
+    data.userPropertiesToSetOnce.forEach(row => {
+        userProperties[row.userProperty] = row.value;
+    });
+
+    const profileBody = {
+        '$token': data.token,
+        '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
+        '$set_once': userProperties
+    };
+
+    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+
+    // Logging the request if logging is enabled
+    if (isLoggingEnabled) {
+        logToConsole(JSON.stringify({
+            'Name': 'Mixpanel',
+            'Type': 'Request',
+            'TraceId': traceId,
+            'EventName': 'Profile Set Once',
+            'RequestMethod': 'POST',
+            'RequestUrl': postUrlSetOnce,
+            'RequestBody': profileBody,
+        }));
+    }
+
+    // Sending the HTTP request to Mixpanel
+    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
+        // Logging the response if logging is enabled
+        if (isLoggingEnabled) {
+            logToConsole(JSON.stringify({
+                'Name': 'Mixpanel',
+                'Type': 'Response',
+                'TraceId': traceId,
+                'EventName': 'Profile Set Once',
                 'ResponseStatusCode': statusCode,
                 'ResponseHeaders': headers,
                 'ResponseBody': body,


### PR DESCRIPTION
Introduce a new feature to set user profile properties only if they are not already set. This includes adding a new option in the template and implementing the `sendSetOnceProfileRequest` function to handle the new profile-set-once request type.