### PR TITLE
feat: add support for profile-set-once in Mixpanel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 **Mixpanel tag can track these action types:**
 
 - Track - tracks Mixpanel events.
+- Identify - merges anonymous ID with first-party User ID.
 - Alias - adds an alias to existing Mixpanel contact.
-- Set Once - sets user profile properties only if they are not already set.
+- Set - sets user profile properties.
+- Set Once - sets user profile properties **only** if they are not already set.
+- Append - appends user profile properties to a list.
 - Reset - resets identification of Mixpanel contact.
 
 
 **Mixpanel tag capabilities:**
 
-- `Automatically handle customer distinct_id` - Mixpanel server API optimized for stateless shared usage; e.g., in a web application, the same mixpanel instance is used across requests for all users. Rather than setting a distinct_id through identity () calls like Mixpanel client-side libraries (where a single Mixpanel instance is tied to a single user), this API requires you to pass the distinct_id with every tracking call.
+- `Automatically handle customer distinct_id` - Mixpanel server API optimized for stateless shared usage; e.g., in a web application, the same mixpanel instance is used across requests for all users. Rather than setting a `distinct_id` through `identity()` calls like Mixpanel client-side libraries (where a single Mixpanel instance is tied to a single user), this API requires you to pass the `distinct_id` with every tracking call.
 - `Send common data with request` - sends user_agent, path, $current_url, $screen_width, $screen_height, $referrer, user ip, etc.
 - `Get parameters from the variable` - extracts parameters from the sGTM variable.
 - `Additional Parameters` - add parameters you need to send to Mixpanel.
@@ -24,7 +27,7 @@
 
 ## Open Source
 
-Mixpanel Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+The **Mixpanel Tag for GTM Server Side** is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
 
 Also, big thanks to our contributors:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - Track - tracks Mixpanel events.
 - Alias - adds an alias to existing Mixpanel contact.
+- Set Once - sets user profile properties only if they are not already set.
 - Reset - resets identification of Mixpanel contact.
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,4 +21,5 @@ versions:
   - sha: 9c64ffe6b2160224ba7fd1e9c62c2a7929a0b1ef
     changeNotes: Add parameters variable support.
   - sha: f883b90a33f7e69e347af0d6ffffd039a69e987c
+    changeNotes: Enhanced 'set-once' user profile property support with improved UI configuration.
     changeNotes: Initial release.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
-homepage: "https://stape.io/"
+homepage: 'https://stape.io/'
 versions:
+  - sha: aac325a304aec10433b005e9507bf18cb29c9743
+    changeNotes: Enhanced set-once user profile property support with improved UI configuration.
   - sha: 77f4014e15641af8677ee96b9a92b9ba42042989
     changeNotes: Added generation UUID v4 for distinct_id.
   - sha: 08caf7f12c53469ee358455489c3168511101c43
@@ -21,5 +23,4 @@ versions:
   - sha: 9c64ffe6b2160224ba7fd1e9c62c2a7929a0b1ef
     changeNotes: Add parameters variable support.
   - sha: f883b90a33f7e69e347af0d6ffffd039a69e987c
-    changeNotes: Enhanced 'set-once' user profile property support with improved UI configuration.
     changeNotes: Initial release.

--- a/template.js
+++ b/template.js
@@ -1,7 +1,6 @@
 const getAllEventData = require('getAllEventData');
 const JSON = require('JSON');
 const sendHttpRequest = require('sendHttpRequest');
-const getTimestampMillis = require('getTimestampMillis');
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 const getContainerVersion = require('getContainerVersion');
@@ -14,13 +13,14 @@ const Object = require('Object');
 const makeNumber = require('makeNumber');
 const getTimestamp = require('getTimestamp');
 
+/**********************************************************************************************/
+
 const postUrl = 'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com');
 const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
-
 
 let cookieOptions = {
     domain: 'auto',
@@ -51,6 +51,9 @@ if (data.type === 'track') {
     return;
 }
 
+/**********************************************************************************************/
+// Vendor related functions
+
 function sendAppendProfileRequest() {
     const propertiesToAppend = {};
     data.userPropertiesToAppend.forEach(row => {
@@ -68,7 +71,6 @@ function sendAppendProfileRequest() {
 
     const postUrlAppend = postUrl + '/engage#profile-list-append';
 
-    // Logging the request if logging is enabled
     if (isLoggingEnabled) {
         logToConsole(JSON.stringify({
             'Name': 'Mixpanel',
@@ -81,9 +83,7 @@ function sendAppendProfileRequest() {
         }));
     }
 
-    // Sending the HTTP request to Mixpanel
     sendHttpRequest(postUrlAppend, (statusCode, headers, body) => {
-        // Logging the response if logging is enabled
         if (isLoggingEnabled) {
             logToConsole(JSON.stringify({
                 'Name': 'Mixpanel',
@@ -96,8 +96,7 @@ function sendAppendProfileRequest() {
             }));
         }
 
-        // Handling the response
-        if (statusCode >= 200 && statusCode < 400) {
+        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
             data.gtmOnSuccess();
         } else {
             data.gtmOnFailure();
@@ -120,7 +119,6 @@ function sendSetProfileRequest() {
 
     const postUrlSet = postUrl + '/engage#profile-set';
 
-    // Logging the request if logging is enabled
     if (isLoggingEnabled) {
         logToConsole(JSON.stringify({
             'Name': 'Mixpanel',
@@ -133,9 +131,7 @@ function sendSetProfileRequest() {
         }));
     }
 
-    // Sending the HTTP request to Mixpanel
     sendHttpRequest(postUrlSet, (statusCode, headers, body) => {
-        // Logging the response if logging is enabled
         if (isLoggingEnabled) {
             logToConsole(JSON.stringify({
                 'Name': 'Mixpanel',
@@ -148,8 +144,7 @@ function sendSetProfileRequest() {
             }));
         }
 
-        // Handling the response
-        if (statusCode >= 200 && statusCode < 400) {
+        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
             data.gtmOnSuccess();
         } else {
             data.gtmOnFailure();
@@ -172,7 +167,6 @@ function sendSetOnceProfileRequest() {
 
     const postUrlSetOnce = postUrl + '/engage#profile-set-once';
 
-    // Logging the request if logging is enabled
     if (isLoggingEnabled) {
         logToConsole(JSON.stringify({
             'Name': 'Mixpanel',
@@ -185,9 +179,7 @@ function sendSetOnceProfileRequest() {
         }));
     }
 
-    // Sending the HTTP request to Mixpanel
     sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
-        // Logging the response if logging is enabled
         if (isLoggingEnabled) {
             logToConsole(JSON.stringify({
                 'Name': 'Mixpanel',
@@ -200,8 +192,7 @@ function sendSetOnceProfileRequest() {
             }));
         }
 
-        // Handling the response
-        if (statusCode >= 200 && statusCode < 400) {
+        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
             data.gtmOnSuccess();
         } else {
             data.gtmOnFailure();
@@ -311,7 +302,11 @@ function sendRequest(eventName, postBody) {
             }));
         }
 
-        if (statusCode >= 200 && statusCode < 400) {
+        // Because of ?verbose=1
+        let parsedBody;
+        if (body) parsedBody = JSON.parse(body);
+
+        if (statusCode >= 200 && statusCode < 400 && parsedBody && parsedBody.status === 1) {
             data.gtmOnSuccess();
         } else {
             data.gtmOnFailure();
@@ -497,9 +492,12 @@ function getSearchEngine(referrer) {
     return null;
 }
 
+/**********************************************************************************************/
+// Helpers
+
 function random() {
     return generateRandom(1000000000000000, 10000000000000000)/10000000000000000;
-  }
+}
   
 function UUID() {
     function s(n) { return h((random() * (1<<(n<<2)))^getTimestamp()).slice(-n); }

--- a/template.js
+++ b/template.js
@@ -41,6 +41,8 @@ if (data.type === 'track') {
     sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
     sendAppendProfileRequest();
+} else if (data.type === 'profile-set-once') {
+    sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
     cookieOptions['max-age'] = 1;
     setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
@@ -140,6 +142,58 @@ function sendSetProfileRequest() {
                 'Type': 'Response',
                 'TraceId': traceId,
                 'EventName': 'Profile Set',
+                'ResponseStatusCode': statusCode,
+                'ResponseHeaders': headers,
+                'ResponseBody': body,
+            }));
+        }
+
+        // Handling the response
+        if (statusCode >= 200 && statusCode < 400) {
+            data.gtmOnSuccess();
+        } else {
+            data.gtmOnFailure();
+        }
+    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+}
+
+function sendSetOnceProfileRequest() {
+    const userProperties = {};
+    data.userPropertiesToSetOnce.forEach(row => {
+        userProperties[row.userProperty] = row.value;
+    });
+
+    const profileBody = {
+        '$token': data.token,
+        '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
+        '$set_once': userProperties
+    };
+
+    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+
+    // Logging the request if logging is enabled
+    if (isLoggingEnabled) {
+        logToConsole(JSON.stringify({
+            'Name': 'Mixpanel',
+            'Type': 'Request',
+            'TraceId': traceId,
+            'EventName': 'Profile Set Once',
+            'RequestMethod': 'POST',
+            'RequestUrl': postUrlSetOnce,
+            'RequestBody': profileBody,
+        }));
+    }
+
+    // Sending the HTTP request to Mixpanel
+    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
+        // Logging the response if logging is enabled
+        if (isLoggingEnabled) {
+            logToConsole(JSON.stringify({
+                'Name': 'Mixpanel',
+                'Type': 'Response',
+                'TraceId': traceId,
+                'EventName': 'Profile Set Once',
                 'ResponseStatusCode': statusCode,
                 'ResponseHeaders': headers,
                 'ResponseBody': body,

--- a/template.tpl
+++ b/template.tpl
@@ -344,6 +344,40 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "GROUP",
+    "name": "setOnceGroup",
+    "displayName": "User Properties to Set Once",
+    "groupStyle": "ZIPPY_OPEN",
+    "subParams": [
+      {
+        "type": "SIMPLE_TABLE",
+        "name": "userPropertiesToSetOnce",
+        "displayName": "",
+        "simpleTableColumns": [
+          {
+            "defaultValue": "",
+            "displayName": "User Property",
+            "name": "userProperty",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Value",
+            "name": "value",
+            "type": "TEXT"
+          }
+        ]
+      }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "type",
+        "paramValue": "profile-set-once",
+        "type": "EQUALS"
+      }
+    ]
+  },
+  {
     "displayName": "Logs Settings",
     "name": "logsGroup",
     "groupStyle": "ZIPPY_CLOSED",

--- a/template.tpl
+++ b/template.tpl
@@ -70,6 +70,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "profile-append",
         "displayValue": "append"
+      },
+      {
+        "value": "profile-set-once",
+        "displayValue": "set-once"
       }
     ],
     "simpleValueType": true,
@@ -415,6 +419,8 @@ if (data.type === 'track') {
     sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
     sendAppendProfileRequest();
+} else if (data.type === 'profile-set-once') {
+    sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
     cookieOptions['max-age'] = 1;
     setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
@@ -462,6 +468,58 @@ function sendAppendProfileRequest() {
                 'Type': 'Response',
                 'TraceId': traceId,
                 'EventName': 'Profile Append',
+                'ResponseStatusCode': statusCode,
+                'ResponseHeaders': headers,
+                'ResponseBody': body,
+            }));
+        }
+
+        // Handling the response
+        if (statusCode >= 200 && statusCode < 400) {
+            data.gtmOnSuccess();
+        } else {
+            data.gtmOnFailure();
+        }
+    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+}
+
+function sendSetOnceProfileRequest() {
+    const userProperties = {};
+    data.userPropertiesToSetOnce.forEach(row => {
+        userProperties[row.userProperty] = row.value;
+    });
+
+    const profileBody = {
+        '$token': data.token,
+        '$distinct_id': getDistinctId(),
+        '$ip': eventData.ip_override || eventData.ip,
+        '$set_once': userProperties
+    };
+
+    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+
+    // Logging the request if logging is enabled
+    if (isLoggingEnabled) {
+        logToConsole(JSON.stringify({
+            'Name': 'Mixpanel',
+            'Type': 'Request',
+            'TraceId': traceId,
+            'EventName': 'Profile Set Once',
+            'RequestMethod': 'POST',
+            'RequestUrl': postUrlSetOnce,
+            'RequestBody': profileBody,
+        }));
+    }
+
+    // Sending the HTTP request to Mixpanel
+    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
+        // Logging the response if logging is enabled
+        if (isLoggingEnabled) {
+            logToConsole(JSON.stringify({
+                'Name': 'Mixpanel',
+                'Type': 'Response',
+                'TraceId': traceId,
+                'EventName': 'Profile Set Once',
                 'ResponseStatusCode': statusCode,
                 'ResponseHeaders': headers,
                 'ResponseBody': body,


### PR DESCRIPTION
Copy of https://github.com/stape-io/mixpanel-tag/pull/11. Fixed the `changeNotes` in `metadata.yaml` from https://github.com/stape-io/mixpanel-tag/pull/11.

I took the opportunity to clean up a bit: removed some comments and improved the response success/failure handling.