### PR TITLE
Feat/consent section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server-gtm-sandboxed-apis.d.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "printWidth": 100,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "quoteProps": "preserve"
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/mixpanel-tag'
 versions:
-  - sha: 13fcc8a70ceed12164cfaa767de9abb2f8afbb74
+  - sha: 212dcf3c7cb7d18ce8257849a27be7bcad4ce997
     changeNotes: Added consent section.
   - sha: de7a264ad3db4c77625e9331e8063844656d4beb
     changeNotes: Added support for more UTMs and started collecting some Click IDs for feature parity with the SDKs.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/mixpanel-tag'
 versions:
+  - sha: 13fcc8a70ceed12164cfaa767de9abb2f8afbb74
+    changeNotes: Added consent section.
   - sha: de7a264ad3db4c77625e9331e8063844656d4beb
     changeNotes: Added support for more UTMs and started collecting some Click IDs for feature parity with the SDKs.
   - sha: aac325a304aec10433b005e9507bf18cb29c9743

--- a/template.js
+++ b/template.js
@@ -1,19 +1,20 @@
-const getAllEventData = require('getAllEventData');
-const JSON = require('JSON');
-const sendHttpRequest = require('sendHttpRequest');
-const setCookie = require('setCookie');
-const getCookieValues = require('getCookieValues');
-const getContainerVersion = require('getContainerVersion');
-const logToConsole = require('logToConsole');
-const getRequestHeader = require('getRequestHeader');
 const generateRandom = require('generateRandom');
-const parseUrl = require('parseUrl');
+const getAllEventData = require('getAllEventData');
+const getContainerVersion = require('getContainerVersion');
+const getCookieValues = require('getCookieValues');
+const getRequestHeader = require('getRequestHeader');
+const getTimestamp = require('getTimestamp');
+const JSON = require('JSON');
+const logToConsole = require('logToConsole');
+const makeNumber = require('makeNumber');
 const makeString = require('makeString');
 const Object = require('Object');
-const makeNumber = require('makeNumber');
-const getTimestamp = require('getTimestamp');
+const parseUrl = require('parseUrl');
+const sendHttpRequest = require('sendHttpRequest');
+const setCookie = require('setCookie');
 
-/**********************************************************************************************/
+/*==============================================================================
+==============================================================================*/
 
 const postUrl = 'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com');
 const containerVersion = getContainerVersion();
@@ -22,526 +23,617 @@ const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
 
+if (!isConsentGivenOrNotRequired(data, eventData)) {
+  return data.gtmOnSuccess();
+}
+
 let cookieOptions = {
-    domain: 'auto',
-    path: '/',
-    samesite: 'Lax',
-    secure: true,
-    'max-age': 31536000, // 1 year
-    httpOnly: false
+  domain: 'auto',
+  path: '/',
+  samesite: 'Lax',
+  secure: true,
+  'max-age': 31536000, // 1 year
+  httpOnly: false
 };
 
 if (data.type === 'track') {
-    sendTrackRequest();
+  sendTrackRequest();
 } else if (data.type === 'alias') {
-    sendAliasRequest();
+  sendAliasRequest();
 } else if (data.type === 'identify') {
-    sendIdentifyRequest();
+  sendIdentifyRequest();
 } else if (data.type === 'profile-set') {
-    sendSetProfileRequest();
+  sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
-    sendAppendProfileRequest();
+  sendAppendProfileRequest();
 } else if (data.type === 'profile-set-once') {
-    sendSetOnceProfileRequest();
+  sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
-    cookieOptions['max-age'] = 1;
-    setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
-    setCookie('stape_mixpanel_device_id', 'empty', cookieOptions);
-    data.gtmOnSuccess();
-    return;
+  cookieOptions['max-age'] = 1;
+  setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
+  setCookie('stape_mixpanel_device_id', 'empty', cookieOptions);
+  data.gtmOnSuccess();
+  return;
 }
 
-/**********************************************************************************************/
-// Vendor related functions
+/*==============================================================================
+  Vendor related functions
+==============================================================================*/
 
 function sendAppendProfileRequest() {
-    const propertiesToAppend = {};
-    data.userPropertiesToAppend.forEach(row => {
-        if (!propertiesToAppend[row.propertyName]) {
-            propertiesToAppend[row.propertyName] = [];
-        }
-        propertiesToAppend[row.propertyName].push(row.valueToAppend);
-    });
-
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$append': propertiesToAppend
-    };
-
-    const postUrlAppend = postUrl + '/engage#profile-list-append';
-
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Append',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlAppend,
-            'RequestBody': profileBody,
-        }));
+  const propertiesToAppend = {};
+  data.userPropertiesToAppend.forEach((row) => {
+    if (!propertiesToAppend[row.propertyName]) {
+      propertiesToAppend[row.propertyName] = [];
     }
+    propertiesToAppend[row.propertyName].push(row.valueToAppend);
+  });
 
-    sendHttpRequest(postUrlAppend, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Append',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$append': propertiesToAppend
+  };
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+  const postUrlAppend = postUrl + '/engage#profile-list-append';
+
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Append',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlAppend,
+        RequestBody: profileBody
+      })
+    );
+  }
+
+  sendHttpRequest(
+    postUrlAppend,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Append',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
+
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendSetProfileRequest() {
-    const userProperties = {};
-    data.userPropertiesTable.forEach(row => {
-        userProperties[row.userProperty] = row.value;
-    });
+  const userProperties = {};
+  data.userPropertiesTable.forEach((row) => {
+    userProperties[row.userProperty] = row.value;
+  });
 
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$ip': eventData.ip_override || eventData.ip,
-        '$set': userProperties
-    };
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$ip': eventData.ip_override || eventData.ip,
+    '$set': userProperties
+  };
 
-    const postUrlSet = postUrl + '/engage#profile-set';
+  const postUrlSet = postUrl + '/engage#profile-set';
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Set',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlSet,
-            'RequestBody': profileBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Set',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlSet,
+        RequestBody: profileBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrlSet, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Set',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrlSet,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Set',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendSetOnceProfileRequest() {
-    const userProperties = {};
-    data.userPropertiesToSetOnce.forEach(row => {
-        userProperties[row.userProperty] = row.value;
-    });
+  const userProperties = {};
+  data.userPropertiesToSetOnce.forEach((row) => {
+    userProperties[row.userProperty] = row.value;
+  });
 
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$ip': eventData.ip_override || eventData.ip,
-        '$set_once': userProperties
-    };
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$ip': eventData.ip_override || eventData.ip,
+    '$set_once': userProperties
+  };
 
-    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+  const postUrlSetOnce = postUrl + '/engage#profile-set-once';
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Set Once',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlSetOnce,
-            'RequestBody': profileBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Set Once',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlSetOnce,
+        RequestBody: profileBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Set Once',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrlSetOnce,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Set Once',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendTrackRequest() {
-    let postBody = {
-        properties: {}
-    };
+  let postBody = {
+    properties: {}
+  };
 
-    if (data.trackCommonData) {
-        postBody = trackCommonData(postBody);
+  if (data.trackCommonData) {
+    postBody = trackCommonData(postBody);
+  }
+
+  if (data.trackFromVariable && data.trackParametersObject) {
+    for (let key in data.trackParametersObject) {
+      postBody.properties[key] = data.trackParametersObject[key];
     }
+  }
 
-    if (data.trackFromVariable && data.trackParametersObject) {
-        for (let key in data.trackParametersObject) {
-            postBody.properties[key] = data.trackParametersObject[key];
-        }
-    }
+  if (data.trackParameters) {
+    data.trackParameters.forEach((d) => {
+      postBody.properties[d.name] = d.value;
+    });
+  }
 
-    if (data.trackParameters) {
-        data.trackParameters.forEach(d => {
-            postBody.properties[d.name] = d.value;
-        });
-    }
+  if (data.trackList) {
+    data.trackList.forEach((d) => {
+      // Check if listValues is a string and have commas
+      if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
+        // Convert a string to an array of strings, removing whitespace characters and dividing by commas
+        postBody.properties[d.listName] = d.listValues.split(',').map((tag) => tag.trim());
+      } else {
+        // If it is not a comma-delimited string, assign the value of listValues unchanged
+        postBody.properties[d.listName] = d.listValues;
+      }
+    });
+  }
 
-    if (data.trackList) {
-        data.trackList.forEach(d => {
-            // Check if listValues is a string and have commas
-            if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
-                // Convert a string to an array of strings, removing whitespace characters and dividing by commas
-                postBody.properties[d.listName] = d.listValues.split(',').map(tag => tag.trim());
-            } else {
-                // If it is not a comma-delimited string, assign the value of listValues unchanged
-                postBody.properties[d.listName] = d.listValues;
-            }
-        });
-    }
+  if (data.trackParametersRemove) {
+    data.trackParametersRemove.forEach((d) => {
+      Object.delete(postBody.properties, d.name);
+    });
+  }
 
-
-    if (data.trackParametersRemove) {
-        data.trackParametersRemove.forEach(d => {
-            Object.delete(postBody.properties, d.name);
-        });
-    }
-
-    sendRequest(data.trackName, postBody);
+  sendRequest(data.trackName, postBody);
 }
 
 function sendAliasRequest() {
-    sendRequest('$create_alias', {
-        properties: {
-            alias: data.alias
-        }
-    });
+  sendRequest('$create_alias', {
+    properties: {
+      alias: data.alias
+    }
+  });
 }
 
 function sendIdentifyRequest() {
-    sendRequest('$identify', {
-        properties: {
-            '$identified_id': data.identifier,
-            '$anon_id': getDistinctId()
-        }
-    });
+  sendRequest('$identify', {
+    properties: {
+      '$identified_id': data.identifier,
+      '$anon_id': getDistinctId()
+    }
+  });
 }
 
 function sendRequest(eventName, postBody) {
-    postBody.event = eventName;
+  postBody.event = eventName;
 
-    if (!postBody.properties) postBody.properties = {};
-    postBody.properties.token = data.token;
+  if (!postBody.properties) postBody.properties = {};
+  postBody.properties.token = data.token;
 
-    if (data.type !== 'identify') {
-        postBody.properties.distinct_id = getDistinctId();
-        postBody.properties['$device_id'] = getDeviceId(postBody.properties.distinct_id);
+  if (data.type !== 'identify') {
+    postBody.properties.distinct_id = getDistinctId();
+    postBody.properties['$device_id'] = getDeviceId(postBody.properties.distinct_id);
 
-        if (data.identifyAuto) setDistinctIdCookies(postBody.properties.distinct_id, postBody.properties['$device_id']);
-    }
+    if (data.identifyAuto)
+      setDistinctIdCookies(postBody.properties.distinct_id, postBody.properties['$device_id']);
+  }
 
-    const postUrl = 'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com') + '/track?verbose=1';
-    postBody = [postBody];
+  const postUrl =
+    'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com') + '/track?verbose=1';
+  postBody = [postBody];
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': eventName,
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrl,
-            'RequestBody': postBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: eventName,
+        RequestMethod: 'POST',
+        RequestUrl: postUrl,
+        RequestBody: postBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrl, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': eventName,
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrl,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: eventName,
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        // Because of ?verbose=1
-        let parsedBody;
-        if (body) parsedBody = JSON.parse(body);
+      // Because of ?verbose=1
+      let parsedBody;
+      if (body) parsedBody = JSON.parse(body);
 
-        if (statusCode >= 200 && statusCode < 400 && parsedBody && parsedBody.status === 1) {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify(postBody));
+      if (statusCode >= 200 && statusCode < 400 && parsedBody && parsedBody.status === 1) {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify(postBody)
+  );
 }
 
 function getDistinctId() {
-    if (!data.identifyAuto) return data.identifyCustom;
+  if (!data.identifyAuto) return data.identifyCustom;
 
-    let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
-    if (mpData) return JSON.parse(mpData).distinct_id;
+  let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
+  if (mpData) return JSON.parse(mpData).distinct_id;
 
-    let distinctIdCookie = getCookieValues('stape_mixpanel_distinct_id')[0];
-    if (distinctIdCookie) return distinctIdCookie;
+  let distinctIdCookie = getCookieValues('stape_mixpanel_distinct_id')[0];
+  if (distinctIdCookie) return distinctIdCookie;
 
-    return UUID();
+  return UUID();
 }
 
 function getDeviceId(distinctId) {
-    if (!data.identifyAuto) return data.identifyCustom;
+  if (!data.identifyAuto) return data.identifyCustom;
 
-    let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
-    if (mpData) return JSON.parse(mpData)['$device_id'];
+  let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
+  if (mpData) return JSON.parse(mpData)['$device_id'];
 
-    let distinctIdCookie = getCookieValues('stape_mixpanel_device_id')[0];
-    if (distinctIdCookie) return distinctIdCookie;
+  let distinctIdCookie = getCookieValues('stape_mixpanel_device_id')[0];
+  if (distinctIdCookie) return distinctIdCookie;
 
-    return distinctId;
+  return distinctId;
 }
 
 function setDistinctIdCookies(distinctId, deviceId) {
-    setCookie('stape_mixpanel_distinct_id', makeString(distinctId), cookieOptions);
-    setCookie('stape_mixpanel_device_id', makeString(deviceId), cookieOptions);
+  setCookie('stape_mixpanel_distinct_id', makeString(distinctId), cookieOptions);
+  setCookie('stape_mixpanel_device_id', makeString(deviceId), cookieOptions);
 }
 
 function trackCommonData(postBody) {
-    postBody = {
-        properties: {
-            'ip': eventData.ip_override || eventData.ip,
-            'mp_lib': 'stape',
-            '$lib_version': '1.0.0',
-        }
-    };
-
-    if (eventData.user_agent) postBody.properties.user_agent = eventData.user_agent;
-    if (eventData.page_path) postBody.properties.path = eventData.page_path;
-    if (eventData.page_location) postBody.properties['$current_url'] = eventData.page_location;
-    if (eventData.screen_resolution) postBody.properties['$screen_width'] = eventData.screen_resolution.split('x')[0];
-    if (eventData.screen_resolution) postBody.properties['$screen_height'] = eventData.screen_resolution.split('x')[1];
-    if (eventData.page_referrer) postBody.properties['$referrer'] = eventData.page_referrer;
-    if (eventData.page_referrer) postBody.properties['$referring_domain'] = parseUrl(eventData.page_referrer).hostname;
-
-    const url = eventData.page_location || getRequestHeader('referer');
-    const urlParsed = parseUrl(url);
-
-    // https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags
-    if (urlParsed) {
-        if (urlParsed.searchParams.utm_source) postBody.properties['utm_source'] = urlParsed.searchParams.utm_source;
-        if (urlParsed.searchParams.utm_campaign) postBody.properties['utm_campaign'] = urlParsed.searchParams.utm_campaign;
-        if (urlParsed.searchParams.utm_medium) postBody.properties['utm_medium'] = urlParsed.searchParams.utm_medium;
-        if (urlParsed.searchParams.utm_term) postBody.properties['utm_term'] = urlParsed.searchParams.utm_term;
-        if (urlParsed.searchParams.utm_content) postBody.properties['utm_content'] = urlParsed.searchParams.utm_content;
-        if (urlParsed.searchParams.utm_id) postBody.properties['utm_id'] = urlParsed.searchParams.utm_id;
-        if (urlParsed.searchParams.utm_source_platform) postBody.properties['utm_source_platform'] = urlParsed.searchParams.utm_source_platform;
-        if (urlParsed.searchParams.utm_campaign_id) postBody.properties['utm_campaign_id'] = urlParsed.searchParams.utm_campaign_id;
-        if (urlParsed.searchParams.utm_creative_format) postBody.properties['utm_creative_format'] = urlParsed.searchParams.utm_creative_format;
-        if (urlParsed.searchParams.utm_marketing_tactic) postBody.properties['utm_marketing_tactic'] = urlParsed.searchParams.utm_marketing_tactic;
-
-        if (urlParsed.searchParams.dclid) postBody.properties['dclid'] = urlParsed.searchParams.dclid;
-        if (urlParsed.searchParams.fbclid) postBody.properties['fbclid'] = urlParsed.searchParams.fbclid;
-        if (urlParsed.searchParams.gclid) postBody.properties['gclid'] = urlParsed.searchParams.gclid;
-        if (urlParsed.searchParams.ko_click_id) postBody.properties['ko_click_id'] = urlParsed.searchParams.ko_click_id;
-        if (urlParsed.searchParams.li_fat_id) postBody.properties['li_fat_id'] = urlParsed.searchParams.li_fat_id;
-        if (urlParsed.searchParams.msclkid) postBody.properties['msclkid'] = urlParsed.searchParams.msclkid;
-        if (urlParsed.searchParams.sccid) postBody.properties['sccid'] = urlParsed.searchParams.sccid;
-        if (urlParsed.searchParams.ttclid) postBody.properties['ttclid'] = urlParsed.searchParams.ttclid;
-        if (urlParsed.searchParams.twclid) postBody.properties['twclid'] = urlParsed.searchParams.twclid;
-        if (urlParsed.searchParams.wbraid) postBody.properties['wbraid'] = urlParsed.searchParams.wbraid;
+  postBody = {
+    properties: {
+      'ip': eventData.ip_override || eventData.ip,
+      'mp_lib': 'stape',
+      '$lib_version': '1.0.0'
     }
+  };
 
-    if (postBody.properties['$referrer']) {
-        let searchEngine = getSearchEngine(postBody.properties['$referrer']);
+  if (eventData.user_agent) postBody.properties.user_agent = eventData.user_agent;
+  if (eventData.page_path) postBody.properties.path = eventData.page_path;
+  if (eventData.page_location) postBody.properties['$current_url'] = eventData.page_location;
+  if (eventData.screen_resolution)
+    postBody.properties['$screen_width'] = eventData.screen_resolution.split('x')[0];
+  if (eventData.screen_resolution)
+    postBody.properties['$screen_height'] = eventData.screen_resolution.split('x')[1];
+  if (eventData.page_referrer) postBody.properties['$referrer'] = eventData.page_referrer;
+  if (eventData.page_referrer)
+    postBody.properties['$referring_domain'] = parseUrl(eventData.page_referrer).hostname;
 
-        if (searchEngine) {
-            let searchEngineKeyword = null;
+  const url = eventData.page_location || getRequestHeader('referer');
+  const urlParsed = parseUrl(url);
 
-            if (urlParsed) {
-                searchEngineKeyword = searchEngine !== 'yahoo' ? urlParsed.searchParams.q : urlParsed.searchParams.p;
-            }
+  // https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags
+  if (urlParsed) {
+    if (urlParsed.searchParams.utm_source)
+      postBody.properties['utm_source'] = urlParsed.searchParams.utm_source;
+    if (urlParsed.searchParams.utm_campaign)
+      postBody.properties['utm_campaign'] = urlParsed.searchParams.utm_campaign;
+    if (urlParsed.searchParams.utm_medium)
+      postBody.properties['utm_medium'] = urlParsed.searchParams.utm_medium;
+    if (urlParsed.searchParams.utm_term)
+      postBody.properties['utm_term'] = urlParsed.searchParams.utm_term;
+    if (urlParsed.searchParams.utm_content)
+      postBody.properties['utm_content'] = urlParsed.searchParams.utm_content;
+    if (urlParsed.searchParams.utm_id)
+      postBody.properties['utm_id'] = urlParsed.searchParams.utm_id;
+    if (urlParsed.searchParams.utm_source_platform)
+      postBody.properties['utm_source_platform'] = urlParsed.searchParams.utm_source_platform;
+    if (urlParsed.searchParams.utm_campaign_id)
+      postBody.properties['utm_campaign_id'] = urlParsed.searchParams.utm_campaign_id;
+    if (urlParsed.searchParams.utm_creative_format)
+      postBody.properties['utm_creative_format'] = urlParsed.searchParams.utm_creative_format;
+    if (urlParsed.searchParams.utm_marketing_tactic)
+      postBody.properties['utm_marketing_tactic'] = urlParsed.searchParams.utm_marketing_tactic;
 
-            postBody.properties['$search_engine'] = searchEngine;
-            if (searchEngineKeyword) postBody.properties['mp_keyword'] = searchEngineKeyword;
-        }
+    if (urlParsed.searchParams.dclid) postBody.properties['dclid'] = urlParsed.searchParams.dclid;
+    if (urlParsed.searchParams.fbclid)
+      postBody.properties['fbclid'] = urlParsed.searchParams.fbclid;
+    if (urlParsed.searchParams.gclid) postBody.properties['gclid'] = urlParsed.searchParams.gclid;
+    if (urlParsed.searchParams.ko_click_id)
+      postBody.properties['ko_click_id'] = urlParsed.searchParams.ko_click_id;
+    if (urlParsed.searchParams.li_fat_id)
+      postBody.properties['li_fat_id'] = urlParsed.searchParams.li_fat_id;
+    if (urlParsed.searchParams.msclkid)
+      postBody.properties['msclkid'] = urlParsed.searchParams.msclkid;
+    if (urlParsed.searchParams.sccid) postBody.properties['sccid'] = urlParsed.searchParams.sccid;
+    if (urlParsed.searchParams.ttclid)
+      postBody.properties['ttclid'] = urlParsed.searchParams.ttclid;
+    if (urlParsed.searchParams.twclid)
+      postBody.properties['twclid'] = urlParsed.searchParams.twclid;
+    if (urlParsed.searchParams.wbraid)
+      postBody.properties['wbraid'] = urlParsed.searchParams.wbraid;
+  }
+
+  if (postBody.properties['$referrer']) {
+    let searchEngine = getSearchEngine(postBody.properties['$referrer']);
+
+    if (searchEngine) {
+      let searchEngineKeyword = null;
+
+      if (urlParsed) {
+        searchEngineKeyword =
+          searchEngine !== 'yahoo' ? urlParsed.searchParams.q : urlParsed.searchParams.p;
+      }
+
+      postBody.properties['$search_engine'] = searchEngine;
+      if (searchEngineKeyword) postBody.properties['mp_keyword'] = searchEngineKeyword;
     }
+  }
 
-    if (postBody.properties.user_agent) {
-        let os = getOS(postBody.properties.user_agent);
-        let device = getDevice(postBody.properties.user_agent);
-        let browser = getBrowser(postBody.properties.user_agent);
-        let browserVersion = getBrowserVersion(postBody.properties.user_agent, browser);
+  if (postBody.properties.user_agent) {
+    let os = getOS(postBody.properties.user_agent);
+    let device = getDevice(postBody.properties.user_agent);
+    let browser = getBrowser(postBody.properties.user_agent);
+    let browserVersion = getBrowserVersion(postBody.properties.user_agent, browser);
 
-        if (os) postBody.properties['$os'] = os;
-        if (device) postBody.properties['$device'] = device;
-        if (browser) postBody.properties['$browser'] = browser;
-        if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
+    if (os) postBody.properties['$os'] = os;
+    if (device) postBody.properties['$device'] = device;
+    if (browser) postBody.properties['$browser'] = browser;
+    if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
+  }
+
+  if (
+    !data.trackParametersRemove ||
+    !data.trackParametersRemove.some((el) => el.name === '$initial_referrer')
+  ) {
+    let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
+    if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
+    if (!initialReferrer) {
+      postBody.properties['$initial_referrer'] = postBody.properties['$referrer']
+        ? postBody.properties['$referrer']
+        : 'direct';
+      setCookie(
+        'stape_mixpanel_initial_referrer',
+        makeString(postBody.properties['$initial_referrer']),
+        cookieOptions
+      );
     }
+  }
 
-    if (!data.trackParametersRemove || !data.trackParametersRemove.some(el => el.name === '$initial_referrer')) {
-        let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
-        if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
-        if (!initialReferrer) {
-            postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
-            setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
-        }
-    }
+  if (
+    postBody.properties['$initial_referrer'] &&
+    postBody.properties['$initial_referrer'] !== 'direct'
+  )
+    postBody.properties['$initial_referring_domain'] = parseUrl(
+      postBody.properties['$initial_referrer']
+    ).hostname;
 
-    if (postBody.properties['$initial_referrer'] && postBody.properties['$initial_referrer'] !== 'direct') postBody.properties['$initial_referring_domain'] = parseUrl(postBody.properties['$initial_referrer']).hostname;
-
-    return postBody;
+  return postBody;
 }
 
 function getOS(userAgent) {
-    if (userAgent.toLowerCase().match('windows') && userAgent.match('Phone')) return 'Windows Mobile';
-    else if (userAgent.toLowerCase().match('windows')) return 'Windows';
-    else if (userAgent.match('(iPhone|iPad|iPod)')) return 'iOS';
-    else if (userAgent.match('Android')) return 'Android';
-    else if (userAgent.match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
-    else if (userAgent.match('Mac')) return 'Mac OS X';
-    else if (userAgent.match('Linux')) return 'Linux';
+  if (userAgent.toLowerCase().match('windows') && userAgent.match('Phone')) return 'Windows Mobile';
+  else if (userAgent.toLowerCase().match('windows')) return 'Windows';
+  else if (userAgent.match('(iPhone|iPad|iPod)')) return 'iOS';
+  else if (userAgent.match('Android')) return 'Android';
+  else if (userAgent.match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
+  else if (userAgent.match('Mac')) return 'Mac OS X';
+  else if (userAgent.match('Linux')) return 'Linux';
 
-    return '';
+  return '';
 }
 
 function getDevice(userAgent) {
-    if (userAgent.match('iPad')) return 'iPad';
-    else if (userAgent.match('iPod')) return 'iPod Touch';
-    else if (userAgent.match('iPhone')) return 'iPhone';
-    else if (userAgent.toLowerCase().match('(blackberry|playbook|bb10)')) return 'BlackBerry';
-    else if (userAgent.toLowerCase().match('windows phone')) return 'Windows Phone';
-    else if (userAgent.match('Android')) return 'Android';
+  if (userAgent.match('iPad')) return 'iPad';
+  else if (userAgent.match('iPod')) return 'iPod Touch';
+  else if (userAgent.match('iPhone')) return 'iPhone';
+  else if (userAgent.toLowerCase().match('(blackberry|playbook|bb10)')) return 'BlackBerry';
+  else if (userAgent.toLowerCase().match('windows phone')) return 'Windows Phone';
+  else if (userAgent.match('Android')) return 'Android';
 
-    return '';
+  return '';
 }
 
 function getBrowser(userAgent) {
-    if (userAgent.match('Opera Mini')) return 'Opera Mini';
-    if (userAgent.match('Opera')) return 'Opera';
-    if (userAgent.toLowerCase().match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
-    if (userAgent.match('FBIOS')) return 'Facebook Mobile';
-    if (userAgent.match('Chrome')) return 'Chrome';
-    if (userAgent.match('CriOS')) return 'Chrome iOS';
-    if (userAgent.match('Apple') && userAgent.match('Mobile')) return 'Mobile Safari';
-    if (userAgent.match('Apple')) return 'Safari';
-    if (userAgent.match('Android')) return 'Android Mobile';
-    if (userAgent.match('Konqueror')) return 'Konqueror';
-    if (userAgent.match('Firefox')) return 'Firefox';
-    if (userAgent.match('MSIE') || userAgent.match('Trident')) return 'Internet Explorer';
-    if (userAgent.match('Gecko')) return 'Mozilla';
+  if (userAgent.match('Opera Mini')) return 'Opera Mini';
+  if (userAgent.match('Opera')) return 'Opera';
+  if (userAgent.toLowerCase().match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
+  if (userAgent.match('FBIOS')) return 'Facebook Mobile';
+  if (userAgent.match('Chrome')) return 'Chrome';
+  if (userAgent.match('CriOS')) return 'Chrome iOS';
+  if (userAgent.match('Apple') && userAgent.match('Mobile')) return 'Mobile Safari';
+  if (userAgent.match('Apple')) return 'Safari';
+  if (userAgent.match('Android')) return 'Android Mobile';
+  if (userAgent.match('Konqueror')) return 'Konqueror';
+  if (userAgent.match('Firefox')) return 'Firefox';
+  if (userAgent.match('MSIE') || userAgent.match('Trident')) return 'Internet Explorer';
+  if (userAgent.match('Gecko')) return 'Mozilla';
 
-    return '';
+  return '';
 }
 
 function getBrowserVersion(userAgent, browser) {
-    const versionRegexs = {
-        'Internet Explorer Mobile': 'rv:([0-9]+(.[0-9]+)?)',
-        'Microsoft Edge': 'Edge?/([0-9]+(.[0-9]+)?)',
-        'Chrome': 'Chrome/([0-9]+(.[0-9]+)?)',
-        'Chrome iOS': 'CriOS/([0-9]+(.[0-9]+)?)',
-        'UC Browser' : '(UCBrowser|UCWEB)/([0-9]+(.[0-9]+)?)',
-        'Safari': 'Version/([0-9]+(.[0-9]+)?)',
-        'Mobile Safari': 'Version/([0-9]+(.[0-9]+)?)',
-        'Opera': '(Opera|OPR)/([0-9]+(.[0-9]+)?)',
-        'Firefox': 'Firefox/([0-9]+(.[0-9]+)?)',
-        'Firefox iOS': 'FxiOS/([0-9]+(.[0-9]+)?)',
-        'Konqueror': 'Konqueror:([0-9]+(.[0-9]+)?)',
-        'BlackBerry': 'BlackBerry ([0-9]+(.[0-9]+)?)',
-        'Android Mobile': 'android.([0-9]+(.[0-9]+)?)',
-        'Samsung Internet': 'SamsungBrowser/([0-9]+(.[0-9]+)?)',
-        'Internet Explorer': '(rv:|MSIE )([0-9]+(.[0-9]+)?)',
-        'Mozilla': 'rv:([0-9]+(.[0-9]+)?)'
-    };
+  const versionRegexs = {
+    'Internet Explorer Mobile': 'rv:([0-9]+(.[0-9]+)?)',
+    'Microsoft Edge': 'Edge?/([0-9]+(.[0-9]+)?)',
+    Chrome: 'Chrome/([0-9]+(.[0-9]+)?)',
+    'Chrome iOS': 'CriOS/([0-9]+(.[0-9]+)?)',
+    'UC Browser': '(UCBrowser|UCWEB)/([0-9]+(.[0-9]+)?)',
+    Safari: 'Version/([0-9]+(.[0-9]+)?)',
+    'Mobile Safari': 'Version/([0-9]+(.[0-9]+)?)',
+    Opera: '(Opera|OPR)/([0-9]+(.[0-9]+)?)',
+    Firefox: 'Firefox/([0-9]+(.[0-9]+)?)',
+    'Firefox iOS': 'FxiOS/([0-9]+(.[0-9]+)?)',
+    Konqueror: 'Konqueror:([0-9]+(.[0-9]+)?)',
+    BlackBerry: 'BlackBerry ([0-9]+(.[0-9]+)?)',
+    'Android Mobile': 'android.([0-9]+(.[0-9]+)?)',
+    'Samsung Internet': 'SamsungBrowser/([0-9]+(.[0-9]+)?)',
+    'Internet Explorer': '(rv:|MSIE )([0-9]+(.[0-9]+)?)',
+    Mozilla: 'rv:([0-9]+(.[0-9]+)?)'
+  };
 
-    let regex = versionRegexs[browser];
-    if (regex === undefined) {
-        return null;
-    }
+  let regex = versionRegexs[browser];
+  if (regex === undefined) {
+    return null;
+  }
 
-    let matches = userAgent.match(regex);
-    if (!matches) {
-        return null;
-    }
+  let matches = userAgent.match(regex);
+  if (!matches) {
+    return null;
+  }
 
-    return makeNumber(matches[matches.length - 2]);
+  return makeNumber(matches[matches.length - 2]);
 }
 
 function getSearchEngine(referrer) {
-    if (referrer.search('https?://(.*)google.([^/?]*)') === 0) return 'google';
-    else if (referrer.search('https?://(.*)bing.com') === 0) return 'bing';
-    else if (referrer.search('https?://(.*)yahoo.com') === 0) return 'yahoo';
-    else if (referrer.search('https?://(.*)duckduckgo.com') === 0) return 'duckduckgo';
+  if (referrer.search('https?://(.*)google.([^/?]*)') === 0) return 'google';
+  else if (referrer.search('https?://(.*)bing.com') === 0) return 'bing';
+  else if (referrer.search('https?://(.*)yahoo.com') === 0) return 'yahoo';
+  else if (referrer.search('https?://(.*)duckduckgo.com') === 0) return 'duckduckgo';
 
-    return null;
+  return null;
 }
 
-/**********************************************************************************************/
-// Helpers
+/*==============================================================================
+  Helpers
+==============================================================================*/
 
 function random() {
-    return generateRandom(1000000000000000, 10000000000000000)/10000000000000000;
+  return generateRandom(1000000000000000, 10000000000000000) / 10000000000000000;
 }
-  
+
+function isConsentGivenOrNotRequired(data, eventData) {
+  if (data.adStorageConsent !== 'required') return true;
+  if (eventData.consent_state) return !!eventData.consent_state.analytics_storage;
+  const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+  return xGaGcs[3] === '1'; // 4th character indicates analytics_storage consent
+}
+
 function UUID() {
-    function s(n) { return h((random() * (1<<(n<<2)))^getTimestamp()).slice(-n); }
-    function h(n) { return (n|0).toString(16); }
-    return  [
-        s(4) + s(4), s(4),
-        '4' + s(3),
-        h(8|(random()*4)) + s(3),
-        getTimestamp().toString(16).slice(-10) + s(2)
-    ].join('-');
+  function s(n) {
+    return h((random() * (1 << (n << 2))) ^ getTimestamp()).slice(-n);
+  }
+  function h(n) {
+    return (n | 0).toString(16);
+  }
+  return [
+    s(4) + s(4),
+    s(4),
+    '4' + s(3),
+    h(8 | (random() * 4)) + s(3),
+    getTimestamp().toString(16).slice(-10) + s(2)
+  ].join('-');
 }
 
 function determinateIsLoggingEnabled() {
-    if (!data.logType) {
-        return isDebug;
-    }
+  if (!data.logType) {
+    return isDebug;
+  }
 
-    if (data.logType === 'no') {
-        return false;
-    }
+  if (data.logType === 'no') {
+    return false;
+  }
 
-    if (data.logType === 'debug') {
-        return isDebug;
-    }
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
 
-    return data.logType === 'always';
+  return data.logType === 'always';
 }

--- a/template.js
+++ b/template.js
@@ -600,7 +600,7 @@ function random() {
 }
 
 function isConsentGivenOrNotRequired(data, eventData) {
-  if (data.adStorageConsent !== 'required') return true;
+  if (data.analyticsStorageConsent !== 'required') return true;
   if (eventData.consent_state) return !!eventData.consent_state.analytics_storage;
   const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
   return xGaGcs[3] === '1'; // 4th character indicates analytics_storage consent

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,12 @@
-﻿___INFO___
+﻿___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
+
+___INFO___
 
 {
   "type": "TAG",
@@ -378,7 +386,7 @@ ___TEMPLATE_PARAMETERS___
     "subParams": [
       {
         "type": "RADIO",
-        "name": "adStorageConsent",
+        "name": "analyticsStorageConsent",
         "displayName": "",
         "radioItems": [
           {
@@ -387,8 +395,8 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "value": "required",
-            "displayValue": "Send data in case marketing consent given",
-            "help": "Aborts the tag execution if marketing consent (\u003ci\u003ead_storage\u003c/i\u003e Google Consent Mode or Stape\u0027s Data Tag parameter) is not given."
+            "displayValue": "Send data in case analytics consent given",
+            "help": "Aborts the tag execution if analytics consent (\u003ci\u003eanalytics_storage\u003c/i\u003e Google Consent Mode or Stape\u0027s Data Tag parameter) is not given."
           }
         ],
         "simpleValueType": true,

--- a/template.tpl
+++ b/template.tpl
@@ -1,12 +1,4 @@
-___TERMS_OF_SERVICE___
-
-By creating or modifying this file you agree to Google Tag Manager's Community
-Template Gallery Developer Terms of Service available at
-https://developers.google.com/tag-manager/gallery-tos (or such other URL as
-Google may provide), as modified from time to time.
-
-
-___INFO___
+﻿___INFO___
 
 {
   "type": "TAG",
@@ -379,6 +371,32 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "GROUP",
+    "name": "tagExecutionConsentSettingsGroup",
+    "displayName": "Tag Execution Consent Settings",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "adStorageConsent",
+        "displayName": "",
+        "radioItems": [
+          {
+            "value": "optional",
+            "displayValue": "Send data always"
+          },
+          {
+            "value": "required",
+            "displayValue": "Send data in case marketing consent given",
+            "help": "Aborts the tag execution if marketing consent (\u003ci\u003ead_storage\u003c/i\u003e Google Consent Mode or Stape\u0027s Data Tag parameter) is not given."
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "optional"
+      }
+    ]
+  },
+  {
     "displayName": "Logs Settings",
     "name": "logsGroup",
     "groupStyle": "ZIPPY_CLOSED",
@@ -411,22 +429,23 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_SERVER___
 
-const getAllEventData = require('getAllEventData');
-const JSON = require('JSON');
-const sendHttpRequest = require('sendHttpRequest');
-const setCookie = require('setCookie');
-const getCookieValues = require('getCookieValues');
-const getContainerVersion = require('getContainerVersion');
-const logToConsole = require('logToConsole');
-const getRequestHeader = require('getRequestHeader');
 const generateRandom = require('generateRandom');
-const parseUrl = require('parseUrl');
+const getAllEventData = require('getAllEventData');
+const getContainerVersion = require('getContainerVersion');
+const getCookieValues = require('getCookieValues');
+const getRequestHeader = require('getRequestHeader');
+const getTimestamp = require('getTimestamp');
+const JSON = require('JSON');
+const logToConsole = require('logToConsole');
+const makeNumber = require('makeNumber');
 const makeString = require('makeString');
 const Object = require('Object');
-const makeNumber = require('makeNumber');
-const getTimestamp = require('getTimestamp');
+const parseUrl = require('parseUrl');
+const sendHttpRequest = require('sendHttpRequest');
+const setCookie = require('setCookie');
 
-/**********************************************************************************************/
+/*==============================================================================
+==============================================================================*/
 
 const postUrl = 'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com');
 const containerVersion = getContainerVersion();
@@ -435,528 +454,619 @@ const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
 
+if (!isConsentGivenOrNotRequired(data, eventData)) {
+  return data.gtmOnSuccess();
+}
+
 let cookieOptions = {
-    domain: 'auto',
-    path: '/',
-    samesite: 'Lax',
-    secure: true,
-    'max-age': 31536000, // 1 year
-    httpOnly: false
+  domain: 'auto',
+  path: '/',
+  samesite: 'Lax',
+  secure: true,
+  'max-age': 31536000, // 1 year
+  httpOnly: false
 };
 
 if (data.type === 'track') {
-    sendTrackRequest();
+  sendTrackRequest();
 } else if (data.type === 'alias') {
-    sendAliasRequest();
+  sendAliasRequest();
 } else if (data.type === 'identify') {
-    sendIdentifyRequest();
+  sendIdentifyRequest();
 } else if (data.type === 'profile-set') {
-    sendSetProfileRequest();
+  sendSetProfileRequest();
 } else if (data.type === 'profile-append') {
-    sendAppendProfileRequest();
+  sendAppendProfileRequest();
 } else if (data.type === 'profile-set-once') {
-    sendSetOnceProfileRequest();
+  sendSetOnceProfileRequest();
 } else if (data.type === 'reset') {
-    cookieOptions['max-age'] = 1;
-    setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
-    setCookie('stape_mixpanel_device_id', 'empty', cookieOptions);
-    data.gtmOnSuccess();
-    return;
+  cookieOptions['max-age'] = 1;
+  setCookie('stape_mixpanel_distinct_id', 'empty', cookieOptions);
+  setCookie('stape_mixpanel_device_id', 'empty', cookieOptions);
+  data.gtmOnSuccess();
+  return;
 }
 
-/**********************************************************************************************/
-// Vendor related functions
+/*==============================================================================
+  Vendor related functions
+==============================================================================*/
 
 function sendAppendProfileRequest() {
-    const propertiesToAppend = {};
-    data.userPropertiesToAppend.forEach(row => {
-        if (!propertiesToAppend[row.propertyName]) {
-            propertiesToAppend[row.propertyName] = [];
-        }
-        propertiesToAppend[row.propertyName].push(row.valueToAppend);
-    });
-
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$append': propertiesToAppend
-    };
-
-    const postUrlAppend = postUrl + '/engage#profile-list-append';
-
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Append',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlAppend,
-            'RequestBody': profileBody,
-        }));
+  const propertiesToAppend = {};
+  data.userPropertiesToAppend.forEach((row) => {
+    if (!propertiesToAppend[row.propertyName]) {
+      propertiesToAppend[row.propertyName] = [];
     }
+    propertiesToAppend[row.propertyName].push(row.valueToAppend);
+  });
 
-    sendHttpRequest(postUrlAppend, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Append',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$append': propertiesToAppend
+  };
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+  const postUrlAppend = postUrl + '/engage#profile-list-append';
+
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Append',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlAppend,
+        RequestBody: profileBody
+      })
+    );
+  }
+
+  sendHttpRequest(
+    postUrlAppend,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Append',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
+
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendSetProfileRequest() {
-    const userProperties = {};
-    data.userPropertiesTable.forEach(row => {
-        userProperties[row.userProperty] = row.value;
-    });
+  const userProperties = {};
+  data.userPropertiesTable.forEach((row) => {
+    userProperties[row.userProperty] = row.value;
+  });
 
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$ip': eventData.ip_override || eventData.ip,
-        '$set': userProperties
-    };
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$ip': eventData.ip_override || eventData.ip,
+    '$set': userProperties
+  };
 
-    const postUrlSet = postUrl + '/engage#profile-set';
+  const postUrlSet = postUrl + '/engage#profile-set';
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Set',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlSet,
-            'RequestBody': profileBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Set',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlSet,
+        RequestBody: profileBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrlSet, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Set',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrlSet,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Set',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendSetOnceProfileRequest() {
-    const userProperties = {};
-    data.userPropertiesToSetOnce.forEach(row => {
-        userProperties[row.userProperty] = row.value;
-    });
+  const userProperties = {};
+  data.userPropertiesToSetOnce.forEach((row) => {
+    userProperties[row.userProperty] = row.value;
+  });
 
-    const profileBody = {
-        '$token': data.token,
-        '$distinct_id': getDistinctId(),
-        '$ip': eventData.ip_override || eventData.ip,
-        '$set_once': userProperties
-    };
+  const profileBody = {
+    '$token': data.token,
+    '$distinct_id': getDistinctId(),
+    '$ip': eventData.ip_override || eventData.ip,
+    '$set_once': userProperties
+  };
 
-    const postUrlSetOnce = postUrl + '/engage#profile-set-once';
+  const postUrlSetOnce = postUrl + '/engage#profile-set-once';
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': 'Profile Set Once',
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrlSetOnce,
-            'RequestBody': profileBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: 'Profile Set Once',
+        RequestMethod: 'POST',
+        RequestUrl: postUrlSetOnce,
+        RequestBody: profileBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrlSetOnce, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': 'Profile Set Once',
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrlSetOnce,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: 'Profile Set Once',
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify([profileBody]));
+      if (statusCode >= 200 && statusCode < 400 && body && body === '1') {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify([profileBody])
+  );
 }
 
 function sendTrackRequest() {
-    let postBody = {
-        properties: {}
-    };
+  let postBody = {
+    properties: {}
+  };
 
-    if (data.trackCommonData) {
-        postBody = trackCommonData(postBody);
+  if (data.trackCommonData) {
+    postBody = trackCommonData(postBody);
+  }
+
+  if (data.trackFromVariable && data.trackParametersObject) {
+    for (let key in data.trackParametersObject) {
+      postBody.properties[key] = data.trackParametersObject[key];
     }
+  }
 
-    if (data.trackFromVariable && data.trackParametersObject) {
-        for (let key in data.trackParametersObject) {
-            postBody.properties[key] = data.trackParametersObject[key];
-        }
-    }
+  if (data.trackParameters) {
+    data.trackParameters.forEach((d) => {
+      postBody.properties[d.name] = d.value;
+    });
+  }
 
-    if (data.trackParameters) {
-        data.trackParameters.forEach(d => {
-            postBody.properties[d.name] = d.value;
-        });
-    }
+  if (data.trackList) {
+    data.trackList.forEach((d) => {
+      // Check if listValues is a string and have commas
+      if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
+        // Convert a string to an array of strings, removing whitespace characters and dividing by commas
+        postBody.properties[d.listName] = d.listValues.split(',').map((tag) => tag.trim());
+      } else {
+        // If it is not a comma-delimited string, assign the value of listValues unchanged
+        postBody.properties[d.listName] = d.listValues;
+      }
+    });
+  }
 
-    if (data.trackList) {
-        data.trackList.forEach(d => {
-            // Check if listValues is a string and have commas
-            if (typeof d.listValues === 'string' && d.listValues.indexOf(',') !== -1) {
-                // Convert a string to an array of strings, removing whitespace characters and dividing by commas
-                postBody.properties[d.listName] = d.listValues.split(',').map(tag => tag.trim());
-            } else {
-                // If it is not a comma-delimited string, assign the value of listValues unchanged
-                postBody.properties[d.listName] = d.listValues;
-            }
-        });
-    }
+  if (data.trackParametersRemove) {
+    data.trackParametersRemove.forEach((d) => {
+      Object.delete(postBody.properties, d.name);
+    });
+  }
 
-
-    if (data.trackParametersRemove) {
-        data.trackParametersRemove.forEach(d => {
-            Object.delete(postBody.properties, d.name);
-        });
-    }
-
-    sendRequest(data.trackName, postBody);
+  sendRequest(data.trackName, postBody);
 }
 
 function sendAliasRequest() {
-    sendRequest('$create_alias', {
-        properties: {
-            alias: data.alias
-        }
-    });
+  sendRequest('$create_alias', {
+    properties: {
+      alias: data.alias
+    }
+  });
 }
 
 function sendIdentifyRequest() {
-    sendRequest('$identify', {
-        properties: {
-            '$identified_id': data.identifier,
-            '$anon_id': getDistinctId()
-        }
-    });
+  sendRequest('$identify', {
+    properties: {
+      '$identified_id': data.identifier,
+      '$anon_id': getDistinctId()
+    }
+  });
 }
 
 function sendRequest(eventName, postBody) {
-    postBody.event = eventName;
+  postBody.event = eventName;
 
-    if (!postBody.properties) postBody.properties = {};
-    postBody.properties.token = data.token;
+  if (!postBody.properties) postBody.properties = {};
+  postBody.properties.token = data.token;
 
-    if (data.type !== 'identify') {
-        postBody.properties.distinct_id = getDistinctId();
-        postBody.properties['$device_id'] = getDeviceId(postBody.properties.distinct_id);
+  if (data.type !== 'identify') {
+    postBody.properties.distinct_id = getDistinctId();
+    postBody.properties['$device_id'] = getDeviceId(postBody.properties.distinct_id);
 
-        if (data.identifyAuto) setDistinctIdCookies(postBody.properties.distinct_id, postBody.properties['$device_id']);
-    }
+    if (data.identifyAuto)
+      setDistinctIdCookies(postBody.properties.distinct_id, postBody.properties['$device_id']);
+  }
 
-    const postUrl = 'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com') + '/track?verbose=1';
-    postBody = [postBody];
+  const postUrl =
+    'https://' + (data.serverEU ? 'api-eu.mixpanel.com' : 'api.mixpanel.com') + '/track?verbose=1';
+  postBody = [postBody];
 
-    if (isLoggingEnabled) {
-        logToConsole(JSON.stringify({
-            'Name': 'Mixpanel',
-            'Type': 'Request',
-            'TraceId': traceId,
-            'EventName': eventName,
-            'RequestMethod': 'POST',
-            'RequestUrl': postUrl,
-            'RequestBody': postBody,
-        }));
-    }
+  if (isLoggingEnabled) {
+    logToConsole(
+      JSON.stringify({
+        Name: 'Mixpanel',
+        Type: 'Request',
+        TraceId: traceId,
+        EventName: eventName,
+        RequestMethod: 'POST',
+        RequestUrl: postUrl,
+        RequestBody: postBody
+      })
+    );
+  }
 
-    sendHttpRequest(postUrl, (statusCode, headers, body) => {
-        if (isLoggingEnabled) {
-            logToConsole(JSON.stringify({
-                'Name': 'Mixpanel',
-                'Type': 'Response',
-                'TraceId': traceId,
-                'EventName': eventName,
-                'ResponseStatusCode': statusCode,
-                'ResponseHeaders': headers,
-                'ResponseBody': body,
-            }));
-        }
+  sendHttpRequest(
+    postUrl,
+    (statusCode, headers, body) => {
+      if (isLoggingEnabled) {
+        logToConsole(
+          JSON.stringify({
+            Name: 'Mixpanel',
+            Type: 'Response',
+            TraceId: traceId,
+            EventName: eventName,
+            ResponseStatusCode: statusCode,
+            ResponseHeaders: headers,
+            ResponseBody: body
+          })
+        );
+      }
 
-        // Because of ?verbose=1
-        let parsedBody;
-        if (body) parsedBody = JSON.parse(body);
+      // Because of ?verbose=1
+      let parsedBody;
+      if (body) parsedBody = JSON.parse(body);
 
-        if (statusCode >= 200 && statusCode < 400 && parsedBody && parsedBody.status === 1) {
-            data.gtmOnSuccess();
-        } else {
-            data.gtmOnFailure();
-        }
-    }, {headers: {'Content-Type': 'application/json'}, method: 'POST'}, JSON.stringify(postBody));
+      if (statusCode >= 200 && statusCode < 400 && parsedBody && parsedBody.status === 1) {
+        data.gtmOnSuccess();
+      } else {
+        data.gtmOnFailure();
+      }
+    },
+    { headers: { 'Content-Type': 'application/json' }, method: 'POST' },
+    JSON.stringify(postBody)
+  );
 }
 
 function getDistinctId() {
-    if (!data.identifyAuto) return data.identifyCustom;
+  if (!data.identifyAuto) return data.identifyCustom;
 
-    let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
-    if (mpData) return JSON.parse(mpData).distinct_id;
+  let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
+  if (mpData) return JSON.parse(mpData).distinct_id;
 
-    let distinctIdCookie = getCookieValues('stape_mixpanel_distinct_id')[0];
-    if (distinctIdCookie) return distinctIdCookie;
+  let distinctIdCookie = getCookieValues('stape_mixpanel_distinct_id')[0];
+  if (distinctIdCookie) return distinctIdCookie;
 
-    return UUID();
+  return UUID();
 }
 
 function getDeviceId(distinctId) {
-    if (!data.identifyAuto) return data.identifyCustom;
+  if (!data.identifyAuto) return data.identifyCustom;
 
-    let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
-    if (mpData) return JSON.parse(mpData)['$device_id'];
+  let mpData = getCookieValues('mp_' + data.token + '_mixpanel')[0];
+  if (mpData) return JSON.parse(mpData)['$device_id'];
 
-    let distinctIdCookie = getCookieValues('stape_mixpanel_device_id')[0];
-    if (distinctIdCookie) return distinctIdCookie;
+  let distinctIdCookie = getCookieValues('stape_mixpanel_device_id')[0];
+  if (distinctIdCookie) return distinctIdCookie;
 
-    return distinctId;
+  return distinctId;
 }
 
 function setDistinctIdCookies(distinctId, deviceId) {
-    setCookie('stape_mixpanel_distinct_id', makeString(distinctId), cookieOptions);
-    setCookie('stape_mixpanel_device_id', makeString(deviceId), cookieOptions);
+  setCookie('stape_mixpanel_distinct_id', makeString(distinctId), cookieOptions);
+  setCookie('stape_mixpanel_device_id', makeString(deviceId), cookieOptions);
 }
 
 function trackCommonData(postBody) {
-    postBody = {
-        properties: {
-            'ip': eventData.ip_override || eventData.ip,
-            'mp_lib': 'stape',
-            '$lib_version': '1.0.0',
-        }
-    };
-
-    if (eventData.user_agent) postBody.properties.user_agent = eventData.user_agent;
-    if (eventData.page_path) postBody.properties.path = eventData.page_path;
-    if (eventData.page_location) postBody.properties['$current_url'] = eventData.page_location;
-    if (eventData.screen_resolution) postBody.properties['$screen_width'] = eventData.screen_resolution.split('x')[0];
-    if (eventData.screen_resolution) postBody.properties['$screen_height'] = eventData.screen_resolution.split('x')[1];
-    if (eventData.page_referrer) postBody.properties['$referrer'] = eventData.page_referrer;
-    if (eventData.page_referrer) postBody.properties['$referring_domain'] = parseUrl(eventData.page_referrer).hostname;
-
-    const url = eventData.page_location || getRequestHeader('referer');
-    const urlParsed = parseUrl(url);
-
-    // https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags
-    if (urlParsed) {
-        if (urlParsed.searchParams.utm_source) postBody.properties['utm_source'] = urlParsed.searchParams.utm_source;
-        if (urlParsed.searchParams.utm_campaign) postBody.properties['utm_campaign'] = urlParsed.searchParams.utm_campaign;
-        if (urlParsed.searchParams.utm_medium) postBody.properties['utm_medium'] = urlParsed.searchParams.utm_medium;
-        if (urlParsed.searchParams.utm_term) postBody.properties['utm_term'] = urlParsed.searchParams.utm_term;
-        if (urlParsed.searchParams.utm_content) postBody.properties['utm_content'] = urlParsed.searchParams.utm_content;
-        if (urlParsed.searchParams.utm_id) postBody.properties['utm_id'] = urlParsed.searchParams.utm_id;
-        if (urlParsed.searchParams.utm_source_platform) postBody.properties['utm_source_platform'] = urlParsed.searchParams.utm_source_platform;
-        if (urlParsed.searchParams.utm_campaign_id) postBody.properties['utm_campaign_id'] = urlParsed.searchParams.utm_campaign_id;
-        if (urlParsed.searchParams.utm_creative_format) postBody.properties['utm_creative_format'] = urlParsed.searchParams.utm_creative_format;
-        if (urlParsed.searchParams.utm_marketing_tactic) postBody.properties['utm_marketing_tactic'] = urlParsed.searchParams.utm_marketing_tactic;
-
-        if (urlParsed.searchParams.dclid) postBody.properties['dclid'] = urlParsed.searchParams.dclid;
-        if (urlParsed.searchParams.fbclid) postBody.properties['fbclid'] = urlParsed.searchParams.fbclid;
-        if (urlParsed.searchParams.gclid) postBody.properties['gclid'] = urlParsed.searchParams.gclid;
-        if (urlParsed.searchParams.ko_click_id) postBody.properties['ko_click_id'] = urlParsed.searchParams.ko_click_id;
-        if (urlParsed.searchParams.li_fat_id) postBody.properties['li_fat_id'] = urlParsed.searchParams.li_fat_id;
-        if (urlParsed.searchParams.msclkid) postBody.properties['msclkid'] = urlParsed.searchParams.msclkid;
-        if (urlParsed.searchParams.sccid) postBody.properties['sccid'] = urlParsed.searchParams.sccid;
-        if (urlParsed.searchParams.ttclid) postBody.properties['ttclid'] = urlParsed.searchParams.ttclid;
-        if (urlParsed.searchParams.twclid) postBody.properties['twclid'] = urlParsed.searchParams.twclid;
-        if (urlParsed.searchParams.wbraid) postBody.properties['wbraid'] = urlParsed.searchParams.wbraid;
+  postBody = {
+    properties: {
+      'ip': eventData.ip_override || eventData.ip,
+      'mp_lib': 'stape',
+      '$lib_version': '1.0.0'
     }
+  };
 
-    if (postBody.properties['$referrer']) {
-        let searchEngine = getSearchEngine(postBody.properties['$referrer']);
+  if (eventData.user_agent) postBody.properties.user_agent = eventData.user_agent;
+  if (eventData.page_path) postBody.properties.path = eventData.page_path;
+  if (eventData.page_location) postBody.properties['$current_url'] = eventData.page_location;
+  if (eventData.screen_resolution)
+    postBody.properties['$screen_width'] = eventData.screen_resolution.split('x')[0];
+  if (eventData.screen_resolution)
+    postBody.properties['$screen_height'] = eventData.screen_resolution.split('x')[1];
+  if (eventData.page_referrer) postBody.properties['$referrer'] = eventData.page_referrer;
+  if (eventData.page_referrer)
+    postBody.properties['$referring_domain'] = parseUrl(eventData.page_referrer).hostname;
 
-        if (searchEngine) {
-            let searchEngineKeyword = null;
+  const url = eventData.page_location || getRequestHeader('referer');
+  const urlParsed = parseUrl(url);
 
-            if (urlParsed) {
-                searchEngineKeyword = searchEngine !== 'yahoo' ? urlParsed.searchParams.q : urlParsed.searchParams.p;
-            }
+  // https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#track-utm-tags
+  if (urlParsed) {
+    if (urlParsed.searchParams.utm_source)
+      postBody.properties['utm_source'] = urlParsed.searchParams.utm_source;
+    if (urlParsed.searchParams.utm_campaign)
+      postBody.properties['utm_campaign'] = urlParsed.searchParams.utm_campaign;
+    if (urlParsed.searchParams.utm_medium)
+      postBody.properties['utm_medium'] = urlParsed.searchParams.utm_medium;
+    if (urlParsed.searchParams.utm_term)
+      postBody.properties['utm_term'] = urlParsed.searchParams.utm_term;
+    if (urlParsed.searchParams.utm_content)
+      postBody.properties['utm_content'] = urlParsed.searchParams.utm_content;
+    if (urlParsed.searchParams.utm_id)
+      postBody.properties['utm_id'] = urlParsed.searchParams.utm_id;
+    if (urlParsed.searchParams.utm_source_platform)
+      postBody.properties['utm_source_platform'] = urlParsed.searchParams.utm_source_platform;
+    if (urlParsed.searchParams.utm_campaign_id)
+      postBody.properties['utm_campaign_id'] = urlParsed.searchParams.utm_campaign_id;
+    if (urlParsed.searchParams.utm_creative_format)
+      postBody.properties['utm_creative_format'] = urlParsed.searchParams.utm_creative_format;
+    if (urlParsed.searchParams.utm_marketing_tactic)
+      postBody.properties['utm_marketing_tactic'] = urlParsed.searchParams.utm_marketing_tactic;
 
-            postBody.properties['$search_engine'] = searchEngine;
-            if (searchEngineKeyword) postBody.properties['mp_keyword'] = searchEngineKeyword;
-        }
+    if (urlParsed.searchParams.dclid) postBody.properties['dclid'] = urlParsed.searchParams.dclid;
+    if (urlParsed.searchParams.fbclid)
+      postBody.properties['fbclid'] = urlParsed.searchParams.fbclid;
+    if (urlParsed.searchParams.gclid) postBody.properties['gclid'] = urlParsed.searchParams.gclid;
+    if (urlParsed.searchParams.ko_click_id)
+      postBody.properties['ko_click_id'] = urlParsed.searchParams.ko_click_id;
+    if (urlParsed.searchParams.li_fat_id)
+      postBody.properties['li_fat_id'] = urlParsed.searchParams.li_fat_id;
+    if (urlParsed.searchParams.msclkid)
+      postBody.properties['msclkid'] = urlParsed.searchParams.msclkid;
+    if (urlParsed.searchParams.sccid) postBody.properties['sccid'] = urlParsed.searchParams.sccid;
+    if (urlParsed.searchParams.ttclid)
+      postBody.properties['ttclid'] = urlParsed.searchParams.ttclid;
+    if (urlParsed.searchParams.twclid)
+      postBody.properties['twclid'] = urlParsed.searchParams.twclid;
+    if (urlParsed.searchParams.wbraid)
+      postBody.properties['wbraid'] = urlParsed.searchParams.wbraid;
+  }
+
+  if (postBody.properties['$referrer']) {
+    let searchEngine = getSearchEngine(postBody.properties['$referrer']);
+
+    if (searchEngine) {
+      let searchEngineKeyword = null;
+
+      if (urlParsed) {
+        searchEngineKeyword =
+          searchEngine !== 'yahoo' ? urlParsed.searchParams.q : urlParsed.searchParams.p;
+      }
+
+      postBody.properties['$search_engine'] = searchEngine;
+      if (searchEngineKeyword) postBody.properties['mp_keyword'] = searchEngineKeyword;
     }
+  }
 
-    if (postBody.properties.user_agent) {
-        let os = getOS(postBody.properties.user_agent);
-        let device = getDevice(postBody.properties.user_agent);
-        let browser = getBrowser(postBody.properties.user_agent);
-        let browserVersion = getBrowserVersion(postBody.properties.user_agent, browser);
+  if (postBody.properties.user_agent) {
+    let os = getOS(postBody.properties.user_agent);
+    let device = getDevice(postBody.properties.user_agent);
+    let browser = getBrowser(postBody.properties.user_agent);
+    let browserVersion = getBrowserVersion(postBody.properties.user_agent, browser);
 
-        if (os) postBody.properties['$os'] = os;
-        if (device) postBody.properties['$device'] = device;
-        if (browser) postBody.properties['$browser'] = browser;
-        if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
+    if (os) postBody.properties['$os'] = os;
+    if (device) postBody.properties['$device'] = device;
+    if (browser) postBody.properties['$browser'] = browser;
+    if (browserVersion) postBody.properties['$browser_version'] = browserVersion;
+  }
+
+  if (
+    !data.trackParametersRemove ||
+    !data.trackParametersRemove.some((el) => el.name === '$initial_referrer')
+  ) {
+    let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
+    if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
+    if (!initialReferrer) {
+      postBody.properties['$initial_referrer'] = postBody.properties['$referrer']
+        ? postBody.properties['$referrer']
+        : 'direct';
+      setCookie(
+        'stape_mixpanel_initial_referrer',
+        makeString(postBody.properties['$initial_referrer']),
+        cookieOptions
+      );
     }
+  }
 
-    if (!data.trackParametersRemove || !data.trackParametersRemove.some(el => el.name === '$initial_referrer')) {
-        let initialReferrer = getCookieValues('stape_mixpanel_initial_referrer')[0];
-        if (initialReferrer) postBody.properties['$initial_referrer'] = initialReferrer;
-        if (!initialReferrer) {
-            postBody.properties['$initial_referrer'] = postBody.properties['$referrer'] ? postBody.properties['$referrer'] : 'direct';
-            setCookie('stape_mixpanel_initial_referrer', makeString(postBody.properties['$initial_referrer']), cookieOptions);
-        }
-    }
+  if (
+    postBody.properties['$initial_referrer'] &&
+    postBody.properties['$initial_referrer'] !== 'direct'
+  )
+    postBody.properties['$initial_referring_domain'] = parseUrl(
+      postBody.properties['$initial_referrer']
+    ).hostname;
 
-    if (postBody.properties['$initial_referrer'] && postBody.properties['$initial_referrer'] !== 'direct') postBody.properties['$initial_referring_domain'] = parseUrl(postBody.properties['$initial_referrer']).hostname;
-
-    return postBody;
+  return postBody;
 }
 
 function getOS(userAgent) {
-    if (userAgent.toLowerCase().match('windows') && userAgent.match('Phone')) return 'Windows Mobile';
-    else if (userAgent.toLowerCase().match('windows')) return 'Windows';
-    else if (userAgent.match('(iPhone|iPad|iPod)')) return 'iOS';
-    else if (userAgent.match('Android')) return 'Android';
-    else if (userAgent.match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
-    else if (userAgent.match('Mac')) return 'Mac OS X';
-    else if (userAgent.match('Linux')) return 'Linux';
+  if (userAgent.toLowerCase().match('windows') && userAgent.match('Phone')) return 'Windows Mobile';
+  else if (userAgent.toLowerCase().match('windows')) return 'Windows';
+  else if (userAgent.match('(iPhone|iPad|iPod)')) return 'iOS';
+  else if (userAgent.match('Android')) return 'Android';
+  else if (userAgent.match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
+  else if (userAgent.match('Mac')) return 'Mac OS X';
+  else if (userAgent.match('Linux')) return 'Linux';
 
-    return '';
+  return '';
 }
 
 function getDevice(userAgent) {
-    if (userAgent.match('iPad')) return 'iPad';
-    else if (userAgent.match('iPod')) return 'iPod Touch';
-    else if (userAgent.match('iPhone')) return 'iPhone';
-    else if (userAgent.toLowerCase().match('(blackberry|playbook|bb10)')) return 'BlackBerry';
-    else if (userAgent.toLowerCase().match('windows phone')) return 'Windows Phone';
-    else if (userAgent.match('Android')) return 'Android';
+  if (userAgent.match('iPad')) return 'iPad';
+  else if (userAgent.match('iPod')) return 'iPod Touch';
+  else if (userAgent.match('iPhone')) return 'iPhone';
+  else if (userAgent.toLowerCase().match('(blackberry|playbook|bb10)')) return 'BlackBerry';
+  else if (userAgent.toLowerCase().match('windows phone')) return 'Windows Phone';
+  else if (userAgent.match('Android')) return 'Android';
 
-    return '';
+  return '';
 }
 
 function getBrowser(userAgent) {
-    if (userAgent.match('Opera Mini')) return 'Opera Mini';
-    if (userAgent.match('Opera')) return 'Opera';
-    if (userAgent.toLowerCase().match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
-    if (userAgent.match('FBIOS')) return 'Facebook Mobile';
-    if (userAgent.match('Chrome')) return 'Chrome';
-    if (userAgent.match('CriOS')) return 'Chrome iOS';
-    if (userAgent.match('Apple') && userAgent.match('Mobile')) return 'Mobile Safari';
-    if (userAgent.match('Apple')) return 'Safari';
-    if (userAgent.match('Android')) return 'Android Mobile';
-    if (userAgent.match('Konqueror')) return 'Konqueror';
-    if (userAgent.match('Firefox')) return 'Firefox';
-    if (userAgent.match('MSIE') || userAgent.match('Trident')) return 'Internet Explorer';
-    if (userAgent.match('Gecko')) return 'Mozilla';
+  if (userAgent.match('Opera Mini')) return 'Opera Mini';
+  if (userAgent.match('Opera')) return 'Opera';
+  if (userAgent.toLowerCase().match('(BlackBerry|PlayBook|BB10)')) return 'BlackBerry';
+  if (userAgent.match('FBIOS')) return 'Facebook Mobile';
+  if (userAgent.match('Chrome')) return 'Chrome';
+  if (userAgent.match('CriOS')) return 'Chrome iOS';
+  if (userAgent.match('Apple') && userAgent.match('Mobile')) return 'Mobile Safari';
+  if (userAgent.match('Apple')) return 'Safari';
+  if (userAgent.match('Android')) return 'Android Mobile';
+  if (userAgent.match('Konqueror')) return 'Konqueror';
+  if (userAgent.match('Firefox')) return 'Firefox';
+  if (userAgent.match('MSIE') || userAgent.match('Trident')) return 'Internet Explorer';
+  if (userAgent.match('Gecko')) return 'Mozilla';
 
-    return '';
+  return '';
 }
 
 function getBrowserVersion(userAgent, browser) {
-    const versionRegexs = {
-        'Internet Explorer Mobile': 'rv:([0-9]+(.[0-9]+)?)',
-        'Microsoft Edge': 'Edge?/([0-9]+(.[0-9]+)?)',
-        'Chrome': 'Chrome/([0-9]+(.[0-9]+)?)',
-        'Chrome iOS': 'CriOS/([0-9]+(.[0-9]+)?)',
-        'UC Browser' : '(UCBrowser|UCWEB)/([0-9]+(.[0-9]+)?)',
-        'Safari': 'Version/([0-9]+(.[0-9]+)?)',
-        'Mobile Safari': 'Version/([0-9]+(.[0-9]+)?)',
-        'Opera': '(Opera|OPR)/([0-9]+(.[0-9]+)?)',
-        'Firefox': 'Firefox/([0-9]+(.[0-9]+)?)',
-        'Firefox iOS': 'FxiOS/([0-9]+(.[0-9]+)?)',
-        'Konqueror': 'Konqueror:([0-9]+(.[0-9]+)?)',
-        'BlackBerry': 'BlackBerry ([0-9]+(.[0-9]+)?)',
-        'Android Mobile': 'android.([0-9]+(.[0-9]+)?)',
-        'Samsung Internet': 'SamsungBrowser/([0-9]+(.[0-9]+)?)',
-        'Internet Explorer': '(rv:|MSIE )([0-9]+(.[0-9]+)?)',
-        'Mozilla': 'rv:([0-9]+(.[0-9]+)?)'
-    };
+  const versionRegexs = {
+    'Internet Explorer Mobile': 'rv:([0-9]+(.[0-9]+)?)',
+    'Microsoft Edge': 'Edge?/([0-9]+(.[0-9]+)?)',
+    Chrome: 'Chrome/([0-9]+(.[0-9]+)?)',
+    'Chrome iOS': 'CriOS/([0-9]+(.[0-9]+)?)',
+    'UC Browser': '(UCBrowser|UCWEB)/([0-9]+(.[0-9]+)?)',
+    Safari: 'Version/([0-9]+(.[0-9]+)?)',
+    'Mobile Safari': 'Version/([0-9]+(.[0-9]+)?)',
+    Opera: '(Opera|OPR)/([0-9]+(.[0-9]+)?)',
+    Firefox: 'Firefox/([0-9]+(.[0-9]+)?)',
+    'Firefox iOS': 'FxiOS/([0-9]+(.[0-9]+)?)',
+    Konqueror: 'Konqueror:([0-9]+(.[0-9]+)?)',
+    BlackBerry: 'BlackBerry ([0-9]+(.[0-9]+)?)',
+    'Android Mobile': 'android.([0-9]+(.[0-9]+)?)',
+    'Samsung Internet': 'SamsungBrowser/([0-9]+(.[0-9]+)?)',
+    'Internet Explorer': '(rv:|MSIE )([0-9]+(.[0-9]+)?)',
+    Mozilla: 'rv:([0-9]+(.[0-9]+)?)'
+  };
 
-    let regex = versionRegexs[browser];
-    if (regex === undefined) {
-        return null;
-    }
+  let regex = versionRegexs[browser];
+  if (regex === undefined) {
+    return null;
+  }
 
-    let matches = userAgent.match(regex);
-    if (!matches) {
-        return null;
-    }
+  let matches = userAgent.match(regex);
+  if (!matches) {
+    return null;
+  }
 
-    return makeNumber(matches[matches.length - 2]);
+  return makeNumber(matches[matches.length - 2]);
 }
 
 function getSearchEngine(referrer) {
-    if (referrer.search('https?://(.*)google.([^/?]*)') === 0) return 'google';
-    else if (referrer.search('https?://(.*)bing.com') === 0) return 'bing';
-    else if (referrer.search('https?://(.*)yahoo.com') === 0) return 'yahoo';
-    else if (referrer.search('https?://(.*)duckduckgo.com') === 0) return 'duckduckgo';
+  if (referrer.search('https?://(.*)google.([^/?]*)') === 0) return 'google';
+  else if (referrer.search('https?://(.*)bing.com') === 0) return 'bing';
+  else if (referrer.search('https?://(.*)yahoo.com') === 0) return 'yahoo';
+  else if (referrer.search('https?://(.*)duckduckgo.com') === 0) return 'duckduckgo';
 
-    return null;
+  return null;
 }
 
-/**********************************************************************************************/
-// Helpers
+/*==============================================================================
+  Helpers
+==============================================================================*/
 
 function random() {
-    return generateRandom(1000000000000000, 10000000000000000)/10000000000000000;
+  return generateRandom(1000000000000000, 10000000000000000) / 10000000000000000;
 }
-  
+
+function isConsentGivenOrNotRequired(data, eventData) {
+  if (data.adStorageConsent !== 'required') return true;
+  if (eventData.consent_state) return !!eventData.consent_state.analytics_storage;
+  const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+  return xGaGcs[3] === '1'; // 4th character indicates analytics_storage consent
+}
+
 function UUID() {
-    function s(n) { return h((random() * (1<<(n<<2)))^getTimestamp()).slice(-n); }
-    function h(n) { return (n|0).toString(16); }
-    return  [
-        s(4) + s(4), s(4),
-        '4' + s(3),
-        h(8|(random()*4)) + s(3),
-        getTimestamp().toString(16).slice(-10) + s(2)
-    ].join('-');
+  function s(n) {
+    return h((random() * (1 << (n << 2))) ^ getTimestamp()).slice(-n);
+  }
+  function h(n) {
+    return (n | 0).toString(16);
+  }
+  return [
+    s(4) + s(4),
+    s(4),
+    '4' + s(3),
+    h(8 | (random() * 4)) + s(3),
+    getTimestamp().toString(16).slice(-10) + s(2)
+  ].join('-');
 }
 
 function determinateIsLoggingEnabled() {
-    if (!data.logType) {
-        return isDebug;
-    }
+  if (!data.logType) {
+    return isDebug;
+  }
 
-    if (data.logType === 'no') {
-        return false;
-    }
+  if (data.logType === 'no') {
+    return false;
+  }
 
-    if (data.logType === 'debug') {
-        return isDebug;
-    }
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
 
-    return data.logType === 'always';
+  return data.logType === 'always';
 }
 
 


### PR DESCRIPTION
 - Added .prettierrc file (with the additional clause `quoteProps: "preserve"`, because Prettier remove object keys quotes by default. In this case is needed because of the character `$` that shows up and GTM don't parse the object with that special character.
 - Formatted code with new Prettier config.
 - Added most up-to-date Consent section.
 - Added consent check on top of code.
 - Replaced separators to the most up-to-date standard.